### PR TITLE
Pako: add Colab prepare/resume flow to pipeline

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -4,6 +4,7 @@ import json
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent
@@ -13,6 +14,12 @@ THUMBS_DIR = UPLOAD_DIR / 'thumbnails'
 METADATA_DIR = UPLOAD_DIR / 'metadata'
 DONE_DIR = UPLOAD_DIR / 'done'
 OUTPUT_YT_DIR = REPO_ROOT / 'output' / 'youtube'
+WORK_JOBS_DIR = REPO_ROOT / 'work' / 'jobs'
+COLAB_JOBS_DIR = REPO_ROOT / 'publishing' / 'musicgen' / 'jobs'
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
 
 
 def run(cmd, cwd=None):
@@ -35,6 +42,13 @@ def load_json(path: Path):
         return json.load(f)
 
 
+def write_json(path: Path, payload: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+
+
 def detect_theme(meta: dict, house: str | None):
     if house:
         return house
@@ -43,21 +57,23 @@ def detect_theme(meta: dict, house: str | None):
 
 
 def ensure_dirs():
-    for p in [DONE_DIR, OUTPUT_YT_DIR]:
+    for p in [DONE_DIR, OUTPUT_YT_DIR, WORK_JOBS_DIR, COLAB_JOBS_DIR]:
         p.mkdir(parents=True, exist_ok=True)
 
 
 def parse_args():
     p = argparse.ArgumentParser(description='End-to-end pipeline for Whispers of the Seven Kingdoms')
     p.add_argument('--slug', help='Existing slug in upload/{songs,thumbnails,metadata}')
-    p.add_argument('--song', help='Song title / request text for future full automation mode')
-    p.add_argument('--mood', help='Mood hint for future generation mode')
+    p.add_argument('--song', help='Song title / request text for pipeline job creation')
+    p.add_argument('--mood', help='Mood hint for generation mode')
     p.add_argument('--house', help='Theme/house hint for thumbnails + metadata')
     p.add_argument('--minutes', type=int, default=42, help='Target duration hint')
     p.add_argument('--public', action='store_true', help='Upload publicly instead of private')
     p.add_argument('--skip-upload', action='store_true', help='Run pipeline but do not upload to YouTube')
     p.add_argument('--skip-done-move', action='store_true', help='Do not move processed source files to upload/done')
     p.add_argument('--dry-run', action='store_true', help='Print steps without executing external scripts')
+    p.add_argument('--prepare-colab', action='store_true', help='Prepare job + status files for manual Colab run')
+    p.add_argument('--resume', action='store_true', help='Resume pipeline after Colab has produced audio')
     return p.parse_args()
 
 
@@ -68,13 +84,57 @@ def infer_slug_from_title(title: str):
     return slug.strip('-')
 
 
+def job_paths(slug: str):
+    work_dir = WORK_JOBS_DIR / slug
+    return {
+        'dir': work_dir,
+        'status': work_dir / 'status.json',
+        'colab_job': COLAB_JOBS_DIR / f'{slug}.job.json',
+    }
+
+
+def prepare_colab_job(slug: str, meta: dict, theme: str, args):
+    paths = job_paths(slug)
+    title = args.song or meta.get('title', slug.replace('-', ' ').title())
+    payload = {
+        'slug': slug,
+        'title': title,
+        'theme': meta.get('theme', theme),
+        'house': args.house or theme,
+        'mood': args.mood or meta.get('mood', []),
+        'minutes': args.minutes,
+        'target_audio_path': f'upload/songs/{slug}.mp3',
+        'created_at': now_iso(),
+        'generator': 'google-colab-musicgen',
+        'status': 'waiting_for_colab',
+    }
+    status = {
+        'slug': slug,
+        'phase': 'waiting_for_colab',
+        'updated_at': now_iso(),
+        'notes': 'Run the matching Colab job and place generated audio into upload/songs/',
+        'job_file': str(paths['colab_job'].relative_to(REPO_ROOT)),
+    }
+    write_json(paths['colab_job'], payload)
+    write_json(paths['status'], status)
+    print(f'OK: prepared Colab job for {slug}')
+    print(f'JOB: {paths["colab_job"]}')
+    print(f'STATUS: {paths["status"]}')
+
+
+def update_status(slug: str, phase: str, **extra):
+    paths = job_paths(slug)
+    payload = {'slug': slug, 'phase': phase, 'updated_at': now_iso(), **extra}
+    write_json(paths['status'], payload)
+
+
 def main():
     args = parse_args()
     ensure_dirs()
 
     slug = args.slug or (infer_slug_from_title(args.song) if args.song else None)
     if not slug:
-        print('ERROR: provide --slug for current repo flow', file=sys.stderr)
+        print('ERROR: provide --slug or --song', file=sys.stderr)
         raise SystemExit(1)
 
     metadata_path = METADATA_DIR / f'{slug}.json'
@@ -85,10 +145,18 @@ def main():
     meta = load_json(metadata_path)
     theme = detect_theme(meta, args.house)
 
+    if args.prepare_colab:
+        prepare_colab_job(slug, meta, theme, args)
+        return
+
     audio_path = find_first(slug, SONGS_DIR, ('.mp3', '.wav', '.ogg'))
     if audio_path is None:
         print(f'ERROR: audio missing for slug {slug} in {SONGS_DIR}', file=sys.stderr)
+        if args.resume:
+            update_status(slug, 'waiting_for_colab', error='audio_missing_on_resume')
         raise SystemExit(1)
+
+    update_status(slug, 'audio_ready', audio=str(audio_path.relative_to(REPO_ROOT)))
 
     thumb_path = find_first(slug, THUMBS_DIR, ('.jpg', '.jpeg', '.png', '.webp'))
     yt_dir = OUTPUT_YT_DIR / slug
@@ -108,6 +176,7 @@ def main():
             print('DRY:', ' '.join(cmd))
         else:
             run(cmd)
+    update_status(slug, 'thumbnail_ready', thumbnail=str(thumb_path.relative_to(REPO_ROOT)))
 
     video_path = yt_dir / 'video.mp4'
     metadata_out = yt_dir / 'metadata.json'
@@ -133,8 +202,11 @@ def main():
         print('DRY:', ' '.join(preflight_cmd))
     else:
         run(metadata_cmd)
+        update_status(slug, 'metadata_ready', metadata=str(metadata_out.relative_to(REPO_ROOT)))
         run(render_cmd)
+        update_status(slug, 'rendered', video=str(video_path.relative_to(REPO_ROOT)))
         run(preflight_cmd)
+        update_status(slug, 'qa_passed')
 
     if not args.skip_upload:
         upload_cmd = [
@@ -148,6 +220,7 @@ def main():
             print('DRY:', ' '.join(upload_cmd))
         else:
             run(upload_cmd)
+            update_status(slug, 'uploaded')
 
     if not args.skip_done_move and not args.dry_run:
         done_slug_dir = DONE_DIR / slug
@@ -157,6 +230,7 @@ def main():
                 target = done_slug_dir / source.name
                 if source.resolve() != target.resolve():
                     shutil.move(str(source), str(target))
+        update_status(slug, 'done', output=str(yt_dir.relative_to(REPO_ROOT)))
 
     print(f'OK: pipeline completed for {slug}')
     print(f'OUTPUT: {yt_dir}')

--- a/publishing/musicgen/jobs/whispers-of-winterfell.job.json
+++ b/publishing/musicgen/jobs/whispers-of-winterfell.job.json
@@ -1,0 +1,16 @@
+{
+  "slug": "whispers-of-winterfell",
+  "title": "Whispers of Winterfell",
+  "theme": "Winterfell",
+  "house": "winterfell",
+  "mood": [
+    "calm",
+    "cold",
+    "melancholic"
+  ],
+  "minutes": 42,
+  "target_audio_path": "upload/songs/whispers-of-winterfell.mp3",
+  "created_at": "2026-03-21T22:43:00.713101+00:00",
+  "generator": "google-colab-musicgen",
+  "status": "waiting_for_colab"
+}

--- a/work/jobs/whispers-of-winterfell/status.json
+++ b/work/jobs/whispers-of-winterfell/status.json
@@ -1,0 +1,7 @@
+{
+  "slug": "whispers-of-winterfell",
+  "phase": "waiting_for_colab",
+  "updated_at": "2026-03-21T22:43:00.713121+00:00",
+  "notes": "Run the matching Colab job and place generated audio into upload/songs/",
+  "job_file": "publishing/musicgen/jobs/whispers-of-winterfell.job.json"
+}


### PR DESCRIPTION
## Summary
- extend `pipeline.py` with `--prepare-colab` and `--resume`
- generate Colab job files under `publishing/musicgen/jobs/`
- track pipeline status under `work/jobs/<slug>/status.json`

## Why
This adds the first practical bridge for a semi-automated Colab workflow:
prepare in repo -> manual Run in Colab -> resume pipeline after audio exists.

Closes #21